### PR TITLE
feat: 注文IDの注文を取得する

### DIFF
--- a/order-service/src/app.module.ts
+++ b/order-service/src/app.module.ts
@@ -5,6 +5,7 @@ import { OrderModule } from './order/order.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrderWriteModel } from './order/infrastructure/order.write-model';
 import { OrderItemWriteModel } from './order/infrastructure/order-item.write-model';
+import { OrderReadModel } from './order/infrastructure/order.read-model';
 
 @Module({
   imports: [OrderModule,
@@ -15,7 +16,7 @@ import { OrderItemWriteModel } from './order/infrastructure/order-item.write-mod
       username: 'postgres',
       password: 'postgres',
       database: 'cqs',
-      entities: [OrderWriteModel, OrderItemWriteModel],
+      entities: [OrderWriteModel, OrderItemWriteModel, OrderReadModel],
       synchronize: false,
       logging: false,
     }),

--- a/order-service/src/order/infrastructure/order-item.write-model.ts
+++ b/order-service/src/order/infrastructure/order-item.write-model.ts
@@ -1,5 +1,4 @@
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
-import { OrderWriteModel } from "./order.write-model";
 
 @Entity({ name: 'ORDER_ITEM', comment: '注文明細' })
 export class OrderItemWriteModel {

--- a/order-service/src/order/infrastructure/order.read-model.ts
+++ b/order-service/src/order/infrastructure/order.read-model.ts
@@ -1,0 +1,28 @@
+import { ViewColumn, ViewEntity } from "typeorm";
+
+@ViewEntity({
+  name: 'VIEW_ORDER',
+  expression: ''
+})
+export class OrderReadModel {
+  @ViewColumn({ name: 'H_ID' })
+  id!: string;
+
+  @ViewColumn({ name: 'H_CUSTOMER_ID' })
+  customerId!: string;
+
+  @ViewColumn({ name: 'H_ORDER_DATE' })
+  orderDate!: Date;
+
+  @ViewColumn({ name: 'D_ID' })
+  orderDetailId!: string;
+
+  @ViewColumn({ name: 'D_ITEM_ID' })
+  orderDetailItemId!: string;
+
+  @ViewColumn({ name: 'D_QUANTITY' })
+  orderDetailQuantity!: number;
+
+  @ViewColumn({ name: 'D_UNIT_PRICE' })
+  orderDetailUnitPrice!: number;
+}

--- a/order-service/src/order/infrastructure/order.write-model.ts
+++ b/order-service/src/order/infrastructure/order.write-model.ts
@@ -1,6 +1,4 @@
 import { Column, Entity, OneToMany, PrimaryColumn } from "typeorm";
-import { OrderItemWriteModel } from "./order-item.write-model";
-
 @Entity({ name: 'ORDER', comment: '注文' })
 export class OrderWriteModel {
   @PrimaryColumn({ name: 'ID', comment: '注文ID' })

--- a/order-service/src/order/order.controller.ts
+++ b/order-service/src/order/order.controller.ts
@@ -1,20 +1,18 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { OrderService } from './order.service';
-
-export class OrderItemDto {
-  itemId: string;
-  quantity: number;
-  unitPrice: number;
-}
-
-export class OrderDto {
-  customerId: string;
-  orderItems: OrderItemDto[];
-}
+import { Body, Controller, Get, NotFoundException, Param, Post } from '@nestjs/common';
+import { OrderDto, OrderReadDto, OrderService } from './order.service';
 
 @Controller('order')
 export class OrderController {
   constructor(private readonly orderService: OrderService) {}
+
+  @Get(':id')
+  async findById(@Param('id') id: string): Promise<OrderReadDto> {
+    const order = await this.orderService.findById(id);
+    if (order == null) {
+      throw new NotFoundException();
+    }
+    return order;
+  }
 
   @Post()
   createOrder(@Body() order: OrderDto) {

--- a/order-service/src/order/order.module.ts
+++ b/order-service/src/order/order.module.ts
@@ -5,14 +5,16 @@ import { SqlOrderRepository } from './infrastructure/sql-order.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrderWriteModel } from './infrastructure/order.write-model';
 import { OrderItemWriteModel } from './infrastructure/order-item.write-model';
+import { OrderReadModel } from './infrastructure/order.read-model';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([OrderWriteModel, OrderItemWriteModel])],
-  providers: [OrderService,
+  imports: [TypeOrmModule.forFeature([OrderWriteModel, OrderItemWriteModel, OrderReadModel])],
+  providers: [
+    OrderService,
     {
       provide: 'ORDER_REPOSITORY',
       useClass: SqlOrderRepository,
-    }
+    },
   ],
   controllers: [OrderController],
 })

--- a/order-service/src/order/order.service.ts
+++ b/order-service/src/order/order.service.ts
@@ -1,8 +1,31 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { OrderDto } from './order.controller';
 import { OrderRepository } from './domain/order.repository';
 import { OrderItem } from './domain/order-item';
 import { Order } from './domain/order';
+export class OrderItemDto {
+  itemId: string;
+  quantity: number;
+  unitPrice: number;
+}
+
+export class OrderDto {
+  customerId: string;
+  orderItems: OrderItemDto[];
+}
+
+export class OrderItemReadDto {
+  id: string;
+  itemId: string;
+  quantity: number;
+  unitPrice: number;
+}
+
+export class OrderReadDto {
+  id: string;
+  customerId: string;
+  orderDate: string;
+  orderItems: OrderItemReadDto[];
+};
 
 @Injectable()
 export class OrderService {
@@ -19,5 +42,27 @@ export class OrderService {
     const { customerId } = orderDto;
     const props = { customerId, orderItems };
     return Order.create(props);
+  }
+
+  async findById(id: string): Promise<OrderReadDto> {
+    const order = await this.orderRepository.findById(id);
+    console.log('findById', order);
+    return order != null ? this.fromDomain(order) : null;
+  }
+
+  private fromDomain(domain: Order): OrderReadDto {
+    const order = new OrderReadDto();
+    order.id = domain.id;
+    order.customerId = domain.customerId;
+    order.orderDate = domain.orderDate.toLocaleDateString('sv-SE');
+    order.orderItems = domain.orderItems.map((orderItem) => {
+      const dto = new OrderItemReadDto();
+      dto.id = orderItem.id;
+      dto.itemId = orderItem.itemId;
+      dto.quantity = orderItem.quantity;
+      dto.unitPrice = orderItem.unitPrice;
+      return dto;
+    });
+    return order;
   }
 }


### PR DESCRIPTION
TypeORMリポジトリを書き込み用と読み込み用に分ける。ドメインリポジトリは一つで、書き込みリポジトリと読み込みリポジトリをドメインリポジトリのコンストラクタに注入する。
データベースに読み込み用のビューを用意し、ビュー用のエンティティを定義する。
注文ドメインリポジトリの注文IDの注文を取得するときに読み込みリポジトリを使用して注文を取得して注文ドメインに変換する。
注文サービスで受け取ったドメインをコントローラが返す形式に変換する。
注文コントローラでは受け取った注文を返す。

OrderItemDtoとOrderDtoクラスをOrderControllerを定義しているファイルからOrderServiceを定義しているファイルに移動する。 取得用のDTOもOrderService側に定義する。
循環参照によりサーバー起動時にエラーが発生して起動できないため。